### PR TITLE
Use supported Eclipse Temurin base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ COPY . /code
 WORKDIR /code
 RUN lein uberjar
 
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jre
 ENV MALLOC_ARENA_MAX=2
 ENV JAVA_TOOL_OPTIONS="-Xms128M -Xmx512M -XX:MaxDirectMemorySize=512M"
 VOLUME /var/lib/xtdb


### PR DESCRIPTION
The `openjdk` base images are unsupported.

Closes #2.