### PR TITLE
Only push container image when allowed

### DIFF
--- a/.github/workflows/container_image.yml
+++ b/.github/workflows/container_image.yml
@@ -72,7 +72,12 @@ jobs:
           # We don't use git context because that doesn't process .dockerignore
           # https://github.com/docker/cli/issues/2827
           context: .
-          push: true
+          push: |
+            ${{
+              github.actor !== 'dependabot[bot]'
+              && (github.event_name == 'push'
+                  || github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login
+            }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/container_image.yml
+++ b/.github/workflows/container_image.yml
@@ -74,7 +74,7 @@ jobs:
           context: .
           push: |
             ${{
-              github.actor !== 'dependabot[bot]'
+              github.actor != 'dependabot[bot]'
               && (github.event_name == 'push'
                   || github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login
             }}

--- a/.github/workflows/container_image.yml
+++ b/.github/workflows/container_image.yml
@@ -72,12 +72,14 @@ jobs:
           # We don't use git context because that doesn't process .dockerignore
           # https://github.com/docker/cli/issues/2827
           context: .
-          push: |
-            github.event_name == 'push' ||
-            (
-              github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login &&
-              github.actor != 'dependabot[bot]'
-            )
+          push: |-
+            ${{
+              github.event_name == 'push' ||
+              (
+                github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login &&
+                github.actor != 'dependabot[bot]'
+                )
+            }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/container_image.yml
+++ b/.github/workflows/container_image.yml
@@ -73,11 +73,11 @@ jobs:
           # https://github.com/docker/cli/issues/2827
           context: .
           push: |
-            ${{
+            github.event_name == 'push' ||
+            (
+              github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login &&
               github.actor != 'dependabot[bot]'
-              && (github.event_name == 'push'
-                  || github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login
-            }}
+            )
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/src/xtdb_http_multinode/core.clj
+++ b/src/xtdb_http_multinode/core.clj
@@ -305,7 +305,8 @@
   (if (get nodes name)
     ;; Node was already added, so we can just return nodes
     nodes
-    (let [node-config {:xtdb/index-store {:kv-store {:xtdb/module `rocks/->kv-store,
+    (let [config (or (System/getenv "XTDB_DATA_DIR") "/var/lib/xtdb")
+          node-config {:xtdb/index-store {:kv-store {:xtdb/module `rocks/->kv-store,
                                                      :db-dir (io/file node-dir name "indexes"),
                                                      :block-cache :xtdb.rocksdb/block-cache}}
                        :xtdb/document-store {:kv-store {:xtdb/module `rocks/->kv-store,


### PR DESCRIPTION
Only push container image when allowed, so the action won't fail on PRs by someone else or dependabot.